### PR TITLE
Add required version field to golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "1"
+
 run:
   timeout: 5m
   tests: true


### PR DESCRIPTION
### **User description**
Add version: "1" (as string) to .golangci.yml to fix configuration validation. The version field is required by golangci-lint and must be specified as a string, not a number.

Fixes:
- "unsupported version of the configuration" error
- Schema validation requiring version as string type

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add required `version: "1"` field to `.golangci.yml`

- Fixes "unsupported version of the configuration" validation error

- Ensures schema compliance with golangci-lint requirements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["golangci-lint config"] -- "missing version field" --> B["validation error"]
  C["version: '1' added"] -- "fixes" --> B
  C -- "complies with" --> D["schema requirements"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Add version field to golangci-lint configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.golangci.yml

<ul><li>Added <code>version: "1"</code> as the first configuration field<br> <li> Resolves schema validation error requiring version as string type<br> <li> Maintains all existing configuration settings unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/unified-thinking/pull/14/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

