### PR TITLE
fix: align go.mod with CI Go version (1.23)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module unified-thinking
 
-go 1.24.0
+go 1.23.0
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.1.0


### PR DESCRIPTION
### **User description**
The go.mod file required Go 1.24.0, but all GitHub Actions workflows are configured to use Go 1.23.x. This mismatch caused lint failures.

Updated go.mod to use Go 1.23.0 to align with:
- CI/CD workflows (.github/workflows/lint.yml, ci.yml)
- Project documentation (CLAUDE.md: "Go 1.23+ required")

Fixes golangci-lint error:
  go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)


___

### **PR Type**
Bug fix


___

### **Description**
- Align go.mod Go version requirement from 1.24.0 to 1.23.0

- Resolves mismatch between go.mod and CI/CD workflows

- Fixes golangci-lint error in GitHub Actions

- Aligns with project documentation requirement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["go.mod requires 1.24.0"] -- "version mismatch" --> B["CI workflows use 1.23.x"]
  B -- "causes lint failure" --> C["golangci-lint error"]
  A -- "update to 1.23.0" --> D["Aligned versions"]
  D -- "resolves" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update Go version requirement to 1.23.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Updated Go version requirement from 1.24.0 to 1.23.0<br> <li> Aligns with CI/CD workflows configured for Go 1.23.x<br> <li> Resolves golangci-lint error in GitHub Actions<br> <li> Matches project documentation requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/unified-thinking/pull/25/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

