### PR TITLE
fix: resolve staticcheck lint errors in benchmark evaluators

### DIFF
--- a/benchmarks/evaluators/calibration.go
+++ b/benchmarks/evaluators/calibration.go
@@ -63,7 +63,8 @@ func ComputeCalibration(results []CalibrationResult) *CalibrationMetrics {
 		if result.Correct {
 			actual = 1.0
 		}
-		brierSum += math.Pow(result.Confidence-actual, 2)
+		diff := result.Confidence - actual
+		brierSum += diff * diff
 	}
 
 	// Calculate metrics

--- a/benchmarks/evaluators/learning.go
+++ b/benchmarks/evaluators/learning.go
@@ -139,7 +139,7 @@ func sortIterationResults(results []IterationResult) {
 
 // FormatLearningReport generates a text report of learning metrics
 func FormatLearningReport(metrics *LearningMetrics) string {
-	report := fmt.Sprintf("Learning Analysis:\n")
+	report := "Learning Analysis:\n"
 	report += fmt.Sprintf("  Initial Accuracy: %.2f%%\n", metrics.InitialAccuracy*100)
 	report += fmt.Sprintf("  Final Accuracy: %.2f%%\n", metrics.FinalAccuracy*100)
 	report += fmt.Sprintf("  Improvement: %.2f%% (%.1f%% relative)\n",
@@ -148,12 +148,12 @@ func FormatLearningReport(metrics *LearningMetrics) string {
 	report += fmt.Sprintf("  Iterations: %d\n", metrics.Iterations)
 
 	if metrics.SignificantImprovement {
-		report += fmt.Sprintf("  Status: SIGNIFICANT improvement detected\n")
+		report += "  Status: SIGNIFICANT improvement detected\n"
 	} else {
-		report += fmt.Sprintf("  Status: No significant improvement\n")
+		report += "  Status: No significant improvement\n"
 	}
 
-	report += fmt.Sprintf("\nAccuracy by Iteration:\n")
+	report += "\nAccuracy by Iteration:\n"
 	for i := 1; i <= metrics.Iterations; i++ {
 		if acc, exists := metrics.AccuracyByIter[i]; exists {
 			report += fmt.Sprintf("  Iteration %d: %.2f%%\n", i, acc*100)


### PR DESCRIPTION
### **User description**
Fixes #29

- Replace `math.Pow(x, 2)` with `x * x` in calibration.go (QF1005)
- Remove unnecessary `fmt.Sprintf` for string literals in learning.go (S1039)

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `math.Pow(x, 2)` with `x * x` in calibration.go

- Remove unnecessary `fmt.Sprintf` calls for string literals in learning.go

- Resolves staticcheck lint errors QF1005 and S1039


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["calibration.go<br/>math.Pow optimization"] --> B["Lint fixes"]
  C["learning.go<br/>fmt.Sprintf removal"] --> B
  B --> D["Cleaner code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calibration.go</strong><dd><code>Replace math.Pow with multiplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

benchmarks/evaluators/calibration.go

<ul><li>Replace <code>math.Pow(result.Confidence-actual, 2)</code> with <code>diff * diff</code> pattern<br> <li> Introduce intermediate <code>diff</code> variable for clarity<br> <li> Fixes QF1005 staticcheck lint error</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/unified-thinking/pull/30/files#diff-5ef3787c436d6c15019972c3615ac1273cee7ce77404a236339a0e8e4d0c4adf">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>learning.go</strong><dd><code>Remove unnecessary fmt.Sprintf for string literals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

benchmarks/evaluators/learning.go

<ul><li>Remove <code>fmt.Sprintf</code> wrapper from string literal "Learning Analysis:\n"<br> <li> Remove <code>fmt.Sprintf</code> from "Status: SIGNIFICANT improvement detected\n"<br> <li> Remove <code>fmt.Sprintf</code> from "Status: No significant improvement\n"<br> <li> Remove <code>fmt.Sprintf</code> from "\nAccuracy by Iteration:\n"<br> <li> Fixes S1039 staticcheck lint error</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/unified-thinking/pull/30/files#diff-1e4a16b20514924b93cc573e27b3b9c9c1084a9499508475347207191d4c8a39">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

