### PR TITLE
ci: bump Go toolchain to 1.25.x

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.x'
           cache: true
 
       - name: Run benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.24.x']
+        go-version: ['1.25.x']
 
     services:
       neo4j:
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           cache: true
 
       - name: golangci-lint
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           cache: true
 
       - name: Build binary


### PR DESCRIPTION
## Problem

#63 (go-sdk \`1.1.0 → 1.4.1\`) merged a \`go 1.25.0\` directive into the top-level \`go.mod\` (via \`go mod tidy\` cascading from go-sdk v1.4.1's own \`go.mod\`, which requires \`go 1.25.0\`). All CI workflows still pin 1.24.x (and benchmark.yml still pins 1.23.x), so every build on main now fails at:

\`\`\`
toolchain version 'go1.24' is less than the module's go directive '1.25.0'
\`\`\`

## Fix

Bump every \`go-version\` pin to \`1.25.x\`:
- \`.github/workflows/ci.yml\` — matrix, Coverage step, Lint step
- \`.github/workflows/benchmarks.yml\` — \`'1.24'\` → \`'1.25'\`
- \`.github/workflows/benchmark.yml\` — was \`'1.23.x'\` (already stale before #63), raised in the same pass

No code changes — CI version alignment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)