### PR TITLE
fix(deps): pin toolchain to go1.25.12 to clear 22 stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module unified-thinking
 
 go 1.25.0
 
+toolchain go1.25.12
+
 require (
 	github.com/dominikbraun/graph v0.23.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
## Problem

The `govulncheck` step in `security.yml` fails with **22 standard-library vulnerabilities** (exit 3).

None of them are dependency vulnerabilities. Every entry in the report reads:

```
Found in: <pkg>@go1.25
Fixed in: <pkg>@go1.25.N
```

So no `go get` fixes any of them — they are all patched by moving the Go toolchain forward.

## Root cause

Toolchain pinning, not a security regression. Nothing in the code or dependencies changed.

`security.yml` sets `go-version-file: 'go.mod'`, and `go.mod` declares `go 1.25.0` — an **exact** patch version, which `setup-go` honors literally. The scan job therefore builds with Go **1.25.0** and correctly reports every stdlib CVE patched in 1.25.1 → 1.25.12.

It is the only workflow pinned that way:

| workflow | pin | resolves to |
|---|---|---|
| `security.yml` | `go-version-file: go.mod` | **1.25.0 exactly** ← outlier |
| `ci.yml` (×3) | `1.25.x` | latest 1.25 patch |
| `benchmark.yml` | `1.25.x` | latest 1.25 patch |
| `benchmarks.yml` | `1.25` | latest 1.25 patch |

## Fix

Add `toolchain go1.25.12` to `go.mod` (2 lines, no workflow change).

Chosen over editing `security.yml` because it raises the **actual floor** rather than just the CI signal. A workflow-only change would turn CI green while a developer building locally with `GOTOOLCHAIN=auto` on 1.25.0 still produced a binary carrying all 22.

This needs no workflow edit because [setup-go v6 states](https://github.com/actions/setup-go#readme): *"Supports both `go` and `toolchain` directives in `go.mod`. If the `toolchain` directive is present, its version is used; otherwise, the action falls back to the `go` directive."*

`go1.25.12` is the latest 1.25.x and matches the highest `Fixed in` in the report.

The `go` directive stays at `1.25.0`, so the declared language-compatibility floor is unchanged.

## Verification

| check | result |
|---|---|
| `go version` (via new directive) | `go1.25.12` |
| `go build ./...` | exit 0 |
| `govulncheck ./...` | **`No vulnerabilities found.`** exit 0 |
| baseline on `main` (control) | exit 3 |

The control was run to confirm the change is what cleared the scan, rather than a local environment difference.

Note: the local baseline reports **21** stdlib vulns on `windows/amd64` vs CI's **22** on `linux/amd64` — some advisories are platform-scoped. Both reach zero with this fix.

## Not addressed here

The 7 pre-existing test failures in `cmd/server` and `internal/server` are unrelated to this change — they fail identically on `main` and are environment gaps (unreachable Neo4j instance, missing API keys), not code defects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to ensure consistent builds and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->