### PR TITLE
fix(ci): grant pull-requests write so benchmark results can post to PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The **Run Reasoning Quality Benchmarks** job has failed on **every `pull_request` run since 2026-05-18 — 8 for 8**, every dependabot PR included. It has never passed on a PR.

The benchmarks themselves run fine. The failure is confined to the `Comment PR with results` step (gated `if: github.event_name == 'pull_request'`), which calls `github.rest.issues.createComment` and gets:

```
403 Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

## Why this was not obvious

Two reasons:

1. **The job already declares `issues: write`.** A permissions block is present, so it reads as though the grant is handled. It is not sufficient to comment on a pull request.
2. **It is green on `main`.** The comment step is skipped on `push` events, so every merge to main shows this workflow passing. Only `pull_request` runs exercise the failing path — so checking main's history actively misleads.

## Evidence

The sibling `benchmark.yml` workflow is a natural control. It makes the **identical** `github.rest.issues.createComment` call through the **same** `actions/github-script@v9`, on the same PRs, and succeeds:

| workflow | permissions | PR runs |
|---|---|---|
| `benchmark.yml` | `contents: write` + **`pull-requests: write`** | **6/6 SUCCESS** |
| `benchmarks.yml` | `contents: read` + `issues: write` | **8/8 FAILURE** |

The only relevant difference is which grant each holds. `pull-requests: write` is what the endpoint requires for a PR; `issues: write` alone is not.

This also **rules out** the repository's `default_workflow_permissions: read` setting as the cause — `benchmark.yml` elevates above that default successfully, so an explicit job-level grant is honored. **No repository setting needs to change.**

## Fix

One line — add `pull-requests: write` to the job's existing permissions block:

```yaml
    permissions:
      contents: read
      issues: write
      pull-requests: write
```

`issues: write` is retained rather than swapped, keeping the change purely additive.

## Verification

`pull_request` events run the workflow file **from the head branch**, so this PR exercises its own fix. If the `Run Reasoning Quality Benchmarks` check passes here — and posts a benchmark-results comment below — that is the fix working end to end, against a two-month streak of failures.

YAML validated: `{'contents': 'read', 'issues': 'write', 'pull-requests': 'write'}`.

## Relationship to #78

Independent. #78 is a two-line `go.mod` toolchain bump for the govulncheck failures. This failure is pre-existing and unrelated to it — it predates #78 by two months. Kept separate deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark automation permissions to support writing pull request results.
  * No changes were made to benchmark behavior or application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->